### PR TITLE
Display league information with `!who` command.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -25,6 +25,7 @@ def user_info_message(user, infos):
     info = infos.get(str(user.id))
     if info is not None:
         osr_username = info.get('osr_username')
+        leagues = info.get('leagues')
         kgs_username = info.get('kgs_username')
         kgs_rank = info.get('kgs_rank')
         ogs_username = info.get('ogs_username')
@@ -44,6 +45,10 @@ def user_info_message(user, infos):
                 servers.append(' KGS | [{u}](http://www.gokgs.com/graphPage.jsp?user={u}) ({r})'.format(u=kgs_username,
                                                                                                         r=kgs_rank))
         message += ' - '.join(servers)
+
+        if leagues is not None:
+            message += '\n\n_Registered leagues_: ' + ' - '.join(leagues)
+
     message += '\n'
     return message
 


### PR DESCRIPTION
Display league information with `!who` command. Closes issue #51 
@climu There is some discrepancy between dev and production. These commands are using the dev branch, but it seems that when "leagues" field is present, "osr_username" field doesn't get a value.

Currently it displayed a "None" username. I will not push the bot in production until you let me know it has been fixed in dev branch.